### PR TITLE
Fix for new resources not being registered without server restart.

### DIFF
--- a/Tests/DbLocalizationProvider.Storage.SqlServer.Tests/ResourceSynchronizedTests/_Tests.cs
+++ b/Tests/DbLocalizationProvider.Storage.SqlServer.Tests/ResourceSynchronizedTests/_Tests.cs
@@ -8,14 +8,67 @@ namespace DbLocalizationProvider.Storage.SqlServer.Tests.ResourceSynchronizedTes
 {
     public class Tests
     {
+        private static DiscoveredResource DefaultDiscoveredResource => new DiscoveredResource(
+            null,
+            "discovered-resource",
+            new List<DiscoveredTranslation> { new DiscoveredTranslation("English discovered resource", "en") },
+            "",
+            null,
+            null,
+            false,
+            false);
+
+        private static DiscoveredResource DefaultDiscoveredModel => new DiscoveredResource(
+            null,
+            "discovered-model",
+            new List<DiscoveredTranslation> { new DiscoveredTranslation("English discovered model", "en") },
+            "",
+            null,
+            null,
+            false,
+            false);
+
         [Fact]
         public void MergeEmptyLists()
         {
             var sut = new ResourceSynchronizer();
 
-            var result = sut.MergeLists(Enumerable.Empty<LocalizationResource>(), null, null);
+            var result = sut.MergeLists(
+                Enumerable.Empty<LocalizationResource>(),
+                new List<DiscoveredResource>(),
+                new List<DiscoveredResource>());
 
             Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Merge_WhenDiscoveredModelsEmpty_ShouldAddDiscoveredResource()
+        {
+            var sut = new ResourceSynchronizer();
+
+            var result = sut.MergeLists(
+                                Enumerable.Empty<LocalizationResource>(),
+                                new List<DiscoveredResource> { DefaultDiscoveredResource },
+                                new List<DiscoveredResource>())
+                            .ToList();
+
+            Assert.NotEmpty(result);
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void Merge_WhenDiscoveredResourcesEmpty_ShouldAddDiscoveredModel()
+        {
+            var sut = new ResourceSynchronizer();
+
+            var result = sut.MergeLists(
+                                Enumerable.Empty<LocalizationResource>(),
+                                new List<DiscoveredResource>(),
+                                new List<DiscoveredResource> { DefaultDiscoveredModel })
+                            .ToList();
+
+            Assert.NotEmpty(result);
+            Assert.Single(result);
         }
 
         [Fact]

--- a/src/DbLocalizationProvider.Storage.SqlServer/ResourceSynchronizer.cs
+++ b/src/DbLocalizationProvider.Storage.SqlServer/ResourceSynchronizer.cs
@@ -41,11 +41,22 @@ namespace DbLocalizationProvider.Storage.SqlServer
             return result;
         }
 
-        internal IEnumerable<LocalizationResource> MergeLists(IEnumerable<LocalizationResource> databaseResources,
+        internal IEnumerable<LocalizationResource> MergeLists(
+            IEnumerable<LocalizationResource> databaseResources,
             List<DiscoveredResource> discoveredResources,
             List<DiscoveredResource> discoveredModels)
         {
-            if (discoveredResources == null || discoveredModels == null || !discoveredResources.Any() || !discoveredModels.Any())
+            if (discoveredResources == null)
+            {
+                throw new ArgumentNullException(nameof(discoveredResources));
+            }
+
+            if (discoveredModels == null)
+            {
+                throw new ArgumentNullException(nameof(discoveredModels));
+            }
+
+            if (!discoveredResources.Any() && !discoveredModels.Any())
                 return databaseResources;
 
             var result = new List<LocalizationResource>(databaseResources);
@@ -58,7 +69,8 @@ namespace DbLocalizationProvider.Storage.SqlServer
             return result;
         }
 
-        private static void CompareAndMerge(ref List<DiscoveredResource> discoveredResources,
+        private static void CompareAndMerge(
+            ref List<DiscoveredResource> discoveredResources,
             Dictionary<string, LocalizationResource> dic,
             ref List<LocalizationResource> result)
         {


### PR DESCRIPTION
- Fixed the list merging.
- Fixed allowing `null` lists. There is no place where the lists are set as nulls and the best practice is to ensure that lists are never nulls.
- Added tests that prove that it works now.
- Created test properties for the default discovered resources - it improves the readability of the new tests. Those can be used to improve other test readability too.