### PR TITLE
Proposal to fix tree view for Legacy Mode

### DIFF
--- a/src/DbLocalizationProvider.AdminUI.Models/LocalizationResourceApiTreeModel.cs
+++ b/src/DbLocalizationProvider.AdminUI.Models/LocalizationResourceApiTreeModel.cs
@@ -44,7 +44,7 @@ namespace DbLocalizationProvider.AdminUI.Models
             _splitChars = legacyMode ? new[] { '.', '+', '/' } : new[] { '.', '+' };
 
             Resources = ConvertToApiModel(resources);
-            Options = options;            
+            Options = options;
         }
 
         internal List<JObject> ConvertToApiModel(List<LocalizationResource> resources)

--- a/src/DbLocalizationProvider.AdminUI.Models/LocalizationResourceApiTreeModel.cs
+++ b/src/DbLocalizationProvider.AdminUI.Models/LocalizationResourceApiTreeModel.cs
@@ -64,7 +64,7 @@ namespace DbLocalizationProvider.AdminUI.Models
                     while (true)
                     {
                         var (head, tail) = list;
-                        var el = children?.FirstOrDefault(c => c[_segmentPropertyName] != null
+                        var el = children.FirstOrDefault(c => c[_segmentPropertyName] != null
                                                               && c[_segmentPropertyName]
                                                                   .ToString()
                                                                   .Equals(head, StringComparison.InvariantCultureIgnoreCase));
@@ -97,12 +97,12 @@ namespace DbLocalizationProvider.AdminUI.Models
                                 el["_classes"] = new JObject { ["row"] = new JObject { ["parent-row"] = true } };
                             }
 
-                            children?.Add(el);
+                            children.Add(el);
                         }
 
                         if (tail.Any())
                         {
-                            children = el["_children"] as JArray;
+                            children = el["_children"] as JArray ?? new JArray();
                             list = tail;
                             currentLevel += 1;
                             continue;


### PR DESCRIPTION
Tree view doesn't work that well in legacy mode due to the way `LocalizationResourceApiTreeModel` uses split characters. 
My proposal is to add an option for it, then later add reading of `ConfigurationContext` in ServiceController to apply the correct values.