### PR TITLE
Optimize ResourceKeyBuilder for some hot paths

### DIFF
--- a/src/DbLocalizationProvider/Internal/StringExtensions.cs
+++ b/src/DbLocalizationProvider/Internal/StringExtensions.cs
@@ -8,13 +8,17 @@ namespace DbLocalizationProvider.Internal;
 
 internal static class StringExtensions
 {
+    internal static string JoinNonEmpty(this string target, string separator, string arg)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        return string.IsNullOrEmpty(arg) ? target : $"{target}{separator}{arg}";
+    }
+    
     internal static string JoinNonEmpty(this string target, string separator, params string[] args)
     {
-        if (target == null)
-        {
-            throw new ArgumentNullException(nameof(target));
-        }
+        ArgumentNullException.ThrowIfNull(target);
 
-        return string.Join(separator, new[] { target }.Union(args.Where(s => !string.IsNullOrEmpty(s)).ToArray()));
+        return string.Join(separator, new[] { target }.Union(args.Where(s => !string.IsNullOrEmpty(s))));
     }
 }

--- a/src/DbLocalizationProvider/ResourceKeyBuilder.cs
+++ b/src/DbLocalizationProvider/ResourceKeyBuilder.cs
@@ -150,7 +150,7 @@ public class ResourceKeyBuilder
 
         var mi = string.IsNullOrEmpty(memberName)
             ? null
-            : containerType.GetMember(memberName).FirstOrDefault();
+            : containerType.GetMember(memberName, MemberTypes.Field | MemberTypes.Property, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public).FirstOrDefault();
         if (mi != null)
         {
             var resourceKeyAttributes = mi.GetCustomAttributes<ResourceKeyAttribute>().ToList();

--- a/src/DbLocalizationProvider/ResourceKeyBuilder.cs
+++ b/src/DbLocalizationProvider/ResourceKeyBuilder.cs
@@ -134,7 +134,6 @@ public class ResourceKeyBuilder
     public string BuildResourceKey(Type containerType, string memberName, string separator = ".")
     {
         var modelAttribute = containerType.GetCustomAttribute<LocalizedModelAttribute>();
-        var mi = containerType.GetMember(memberName).FirstOrDefault();
 
         var prefix = string.Empty;
 
@@ -149,6 +148,9 @@ public class ResourceKeyBuilder
             prefix = resourceAttributeOnClass.KeyPrefix;
         }
 
+        var mi = string.IsNullOrEmpty(memberName)
+            ? null
+            : containerType.GetMember(memberName).FirstOrDefault();
         if (mi != null)
         {
             var resourceKeyAttributes = mi.GetCustomAttributes<ResourceKeyAttribute>().ToList();

--- a/src/DbLocalizationProvider/ResourceKeyBuilder.cs
+++ b/src/DbLocalizationProvider/ResourceKeyBuilder.cs
@@ -133,19 +133,21 @@ public class ResourceKeyBuilder
     /// <returns>Full length resource key</returns>
     public string BuildResourceKey(Type containerType, string memberName, string separator = ".")
     {
-        var modelAttribute = containerType.GetCustomAttribute<LocalizedModelAttribute>();
-
         var prefix = string.Empty;
 
+        var modelAttribute = containerType.GetCustomAttribute<LocalizedModelAttribute>();
         if (!string.IsNullOrEmpty(modelAttribute?.KeyPrefix))
         {
             prefix = modelAttribute.KeyPrefix;
         }
 
-        var resourceAttributeOnClass = containerType.GetCustomAttribute<LocalizedResourceAttribute>();
-        if (!string.IsNullOrEmpty(resourceAttributeOnClass?.KeyPrefix))
+        if (string.IsNullOrEmpty(prefix))
         {
-            prefix = resourceAttributeOnClass.KeyPrefix;
+            var resourceAttributeOnClass = containerType.GetCustomAttribute<LocalizedResourceAttribute>();
+            if (!string.IsNullOrEmpty(resourceAttributeOnClass?.KeyPrefix))
+            {
+                prefix = resourceAttributeOnClass.KeyPrefix;
+            }   
         }
 
         var mi = string.IsNullOrEmpty(memberName)


### PR DESCRIPTION
Using this add-on on an Optimizely CMS 12 site.

I recently did a code profiling session and found that reflection takes a relative high amount of the response time.

This PR adds some optimizations by limiting when to perform heavy operations.