### PR TITLE
Xliff format parser support for CDataTag and ResourceStringContent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        shell: powershell
+        shell: pwsh
         run: |
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"valdisiljuconoks_LocalizationProvider" /o:"valdisiljuconoks" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"valdisiljuconoks_LocalizationProvider" /o:"valdisiljuconoks" /d:sonar.token='${{ secrets.SONAR_TOKEN }}' /d:sonar.host.url="https://sonarcloud.io"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"valdisiljuconoks_LocalizationProvider" /o:"valdisiljuconoks" /d:sonar.token=$env:SONAR_TOKEN /d:sonar.host.url="https://sonarcloud.io"
           dotnet build
           dotnet test --filter Category!=Integration /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=coverage 
-          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token='${{ secrets.SONAR_TOKEN }}'
+          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token=$env:SONAR_TOKEN

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -33,7 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarCloud scanner
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
-        shell: powershell
+        shell: pwsh
         run: |
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,6 @@ jobs:
         run: |
           New-Item -Path ./.sonar/scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
-      - name: Debug secrets variable
-        env:
-          SECRETS: ${{ toJson(secrets) }}
-        shell: pwsh
-        run: |
-          $secrets = ConvertFrom-JSON $env:SECRETS;
-          $secrets | Get-Member -MemberType NoteProperty | ForEach-Object {$_.Name};
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,13 @@ jobs:
         run: |
           New-Item -Path ./.sonar/scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
+      - name: Debug secrets variable
+        env:
+          SECRETS: ${{ toJson(secrets) }}
+        shell: pwsh
+        run: |
+          $secrets = ConvertFrom-JSON $env:SECRETS;
+          $secrets | Get-Member -MemberType NoteProperty | ForEach-Object {$_.Name};
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,29 +21,29 @@ jobs:
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
-          path: ~\sonar\cache
+          path: ~/sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
         uses: actions/cache@v3
         with:
-          path: .\.sonar\scanner
+          path: ./.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarCloud scanner
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          New-Item -Path .\.sonar\scanner -ItemType Directory
-          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+          New-Item -Path ./.sonar/scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"valdisiljuconoks_LocalizationProvider" /o:"valdisiljuconoks" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"valdisiljuconoks_LocalizationProvider" /o:"valdisiljuconoks" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build
           dotnet test --filter Category!=Integration /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=coverage 
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"valdisiljuconoks_LocalizationProvider" /o:"valdisiljuconoks" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"valdisiljuconoks_LocalizationProvider" /o:"valdisiljuconoks" /d:sonar.token='${{ secrets.SONAR_TOKEN }}' /d:sonar.host.url="https://sonarcloud.io"
           dotnet build
           dotnet test --filter Category!=Integration /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=coverage 
-          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token='${{ secrets.SONAR_TOKEN }}'

--- a/DbLocalizationProvider.sln
+++ b/DbLocalizationProvider.sln
@@ -63,6 +63,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbLocalizationProvider.Xlif
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbLocalizationProvider.Translator.Azure", "src\DbLocalizationProvider.Translator.Azure\DbLocalizationProvider.Translator.Azure.csproj", "{284C157F-07EA-450B-826F-BA288EA00E25}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbLocalizationProvider.Xliff.Tests", "Tests\DbLocalizationProvider.Xliff.Tests\DbLocalizationProvider.Xliff.Tests.csproj", "{8D775E3A-BA9A-4E9F-A74E-16B483385810}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,10 @@ Global
 		{284C157F-07EA-450B-826F-BA288EA00E25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{284C157F-07EA-450B-826F-BA288EA00E25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{284C157F-07EA-450B-826F-BA288EA00E25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D775E3A-BA9A-4E9F-A74E-16B483385810}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D775E3A-BA9A-4E9F-A74E-16B483385810}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D775E3A-BA9A-4E9F-A74E-16B483385810}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D775E3A-BA9A-4E9F-A74E-16B483385810}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +132,7 @@ Global
 		{EAB35BEA-94DE-4894-ABC3-5F306C5995F6} = {C79C0F5F-7C56-42C8-84EB-31342C7609F7}
 		{D2278279-6985-44D0-BC7E-4D0145373812} = {DF259C87-9633-46AF-B6E5-AA44E34878AB}
 		{C6BFB34C-8373-4B29-83BA-C1AFD82818F7} = {DF259C87-9633-46AF-B6E5-AA44E34878AB}
+		{8D775E3A-BA9A-4E9F-A74E-16B483385810} = {DF259C87-9633-46AF-B6E5-AA44E34878AB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3132F4CD-7EB0-41DD-B326-F4C39FF97FD0}

--- a/Tests/DbLocalizationProvider.Storage.PostgreSql.Tests/DbLocalizationProvider.Storage.PostgreSql.Tests.csproj
+++ b/Tests/DbLocalizationProvider.Storage.PostgreSql.Tests/DbLocalizationProvider.Storage.PostgreSql.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.9.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/DbLocalizationProvider.Storage.PostgreSql.Tests/ResourceRepositoryTests.cs
+++ b/Tests/DbLocalizationProvider.Storage.PostgreSql.Tests/ResourceRepositoryTests.cs
@@ -9,7 +9,9 @@ namespace DbLocalizationProvider.Storage.PostgreSql.Tests;
 
 public class ResourceRepositoryTests : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder().Build();
+    private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder()
+        .WithImage("postgres:16.4")
+        .Build();
 
     public async Task InitializeAsync()
     {
@@ -29,7 +31,8 @@ public class ResourceRepositoryTests : IAsyncLifetime
         var ctx = new ConfigurationContext();
         var wrapper = new OptionsWrapper<ConfigurationContext>(ctx);
         var repo = new ResourceRepository(wrapper);
-        var original = new LocalizationResource("testKey", false){
+        var original = new LocalizationResource("testKey", false)
+        {
             IsHidden = false,
             FromCode = false,
             IsModified = true,

--- a/Tests/DbLocalizationProvider.Tests/EnumTests/SampleEnumWithAdditionalTranslations.cs
+++ b/Tests/DbLocalizationProvider.Tests/EnumTests/SampleEnumWithAdditionalTranslations.cs
@@ -11,6 +11,6 @@ public enum SampleEnumWithAdditionalTranslations
     [Display(Name = "This is new")]
     New = 1,
 
-    [TranslationForCulture("Åpen", "no")]
+    [TranslationForCulture("Ã…pen", "no")]
     Open = 2
 }

--- a/Tests/DbLocalizationProvider.Xliff.Tests/DbLocalizationProvider.Xliff.Tests.csproj
+++ b/Tests/DbLocalizationProvider.Xliff.Tests/DbLocalizationProvider.Xliff.Tests.csproj
@@ -1,7 +1,7 @@
-﻿ï»¿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\strongname.snk</AssemblyOriginatorKeyFile>
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/DbLocalizationProvider.Xliff.Tests/ExportImprtIntgrTests.cs
+++ b/Tests/DbLocalizationProvider.Xliff.Tests/ExportImprtIntgrTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using DbLocalizationProvider.Abstractions;
 using Xunit;
 
 namespace DbLocalizationProvider.Xliff.Tests
@@ -10,25 +11,25 @@ namespace DbLocalizationProvider.Xliff.Tests
         [Fact]
         public void ExportResourceWithForbiddenKeyName_NoExceptions()
         {
-            var resources = new List<LocalizationResource>
-                            {
-                                new LocalizationResource("My.Resource.Key+ForbiddenPart")
-                                {
-                                    Translations = new List<LocalizationResourceTranslation>
-                                                   {
-                                                       new LocalizationResourceTranslation
-                                                       {
-                                                           Language = "en",
-                                                           Value = "this is english text"
-                                                       }
-                                                   }
-                                }
-                            };
+            var first = new LocalizationResource("My.Resource.Key+ForbiddenPart", false);
+            first.Translations.Add(
+                new LocalizationResourceTranslation
+                {
+                    Language = "en",
+                    Value = "this is english text"
+                });
 
-            var exporter = new Exporter();
+            var resources = new List<LocalizationResource>(){
+                first
+            };
+
+            var exporter = new XliffResourceExporter();
             var parser = new FormatParser();
 
-            var exportResult = exporter.Export(resources, new CultureInfo("en"), new CultureInfo("no"));
+            var exportResult = exporter.Export(resources, new Dictionary<string, string[]>(){
+                {"sourceLang", ["en"]},
+                {"targetLang", ["no"]}
+            });
             Assert.NotNull(exportResult.SerializedData);
 
             var importResult = parser.Parse(exportResult.SerializedData);

--- a/Tests/DbLocalizationProvider.Xliff.Tests/TestXliffExport.cs
+++ b/Tests/DbLocalizationProvider.Xliff.Tests/TestXliffExport.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
+using DbLocalizationProvider.Abstractions;
 using Xunit;
 
 namespace DbLocalizationProvider.Xliff.Tests
@@ -9,45 +10,46 @@ namespace DbLocalizationProvider.Xliff.Tests
         [Fact]
         public void SimpleTest_EmptyDocument()
         {
+            var first = new LocalizationResource("My.Resource.Key", false);
+            first.Translations.Add(
+                new LocalizationResourceTranslation
+                {
+                    Language = "en",
+                    Value = "this is english text"
+                });
+            first.Translations.Add(
+                new LocalizationResourceTranslation
+                {
+                    Language = "no",
+                    Value = "det er tekst i norsk"
+                });
+
+            var second = new LocalizationResource("My.Resource.AnotherKey", false);
+            second.Translations.Add(
+                new LocalizationResourceTranslation
+                {
+                    Language = "en",
+                    Value = "this is another english text"
+                });
+            second.Translations.Add(
+                new LocalizationResourceTranslation
+                {
+                    Language = "no",
+                    Value = "det er andre tekst i norsk"
+                });
+
             var resources = new List<LocalizationResource>
                             {
-                                new LocalizationResource("My.Resource.Key")
-                                {
-                                    Translations = new List<LocalizationResourceTranslation>
-                                                   {
-                                                       new LocalizationResourceTranslation
-                                                       {
-                                                           Language = "en",
-                                                           Value = "this is english text"
-                                                       },
-                                                       new LocalizationResourceTranslation
-                                                       {
-                                                           Language = "no",
-                                                           Value = "det er tekst i norsk"
-                                                       }
-                                                   }
-                                },
-                                new LocalizationResource("My.Resource.AnotherKey")
-                                {
-                                    Translations = new List<LocalizationResourceTranslation>
-                                                   {
-                                                       new LocalizationResourceTranslation
-                                                       {
-                                                           Language = "en",
-                                                           Value = "this is another english text"
-                                                       },
-                                                       new LocalizationResourceTranslation
-                                                       {
-                                                           Language = "no",
-                                                           Value = "det er andre tekst i norsk"
-                                                       }
-                                                   }
-                                }
+                                first,
+                                second
                             };
 
-            var sut = new Exporter();
+            var sut = new XliffResourceExporter();
 
-            var result = sut.Export(resources, new CultureInfo("en"), new CultureInfo("no"));
+            var result = sut.Export(resources, new Dictionary<string, string[]>(){
+                {"sourceLang", ["en"]},
+                {"targetLang", ["no"]}
+            });
 
             Assert.NotNull(result);
         }
@@ -55,23 +57,23 @@ namespace DbLocalizationProvider.Xliff.Tests
         [Fact]
         public void ExportResourceWithForbiddenKeyName_NoExceptions()
         {
+            var first = new LocalizationResource("My.Resource.Key+ForbiddenPart", false);
+            first.Translations.Add(
+                new LocalizationResourceTranslation
+                {
+                    Language = "en",
+                    Value = "this is english text"
+                });
             var resources = new List<LocalizationResource>
                             {
-                                new LocalizationResource("My.Resource.Key+ForbiddenPart")
-                                {
-                                    Translations = new List<LocalizationResourceTranslation>
-                                                   {
-                                                       new LocalizationResourceTranslation
-                                                       {
-                                                           Language = "en",
-                                                           Value = "this is english text"
-                                                       }
-                                                   }
-                                }
+                                first
                             };
 
-            var sut = new Exporter();
-            var result = sut.Export(resources, new CultureInfo("en"), new CultureInfo("no"));
+            var sut = new XliffResourceExporter();
+            var result = sut.Export(resources, new Dictionary<string, string[]>(){
+                {"sourceLang", ["en"]},
+                {"targetLang", ["no"]}
+            });
 
             Assert.NotNull(result);
         }

--- a/Tests/DbLocalizationProvider.Xliff.Tests/TestXliffImport.cs
+++ b/Tests/DbLocalizationProvider.Xliff.Tests/TestXliffImport.cs
@@ -21,9 +21,7 @@ namespace DbLocalizationProvider.Xliff.Tests
 				<source>
 					<![CDATA[this is another english text]]>
 				</source>
-				<target>
-					<![CDATA[det er andre tekst i norsk]]>
-				</target>
+				<target>det er andre tekst i norsk</target>
 			</segment>
 		</unit>
 	</file>
@@ -39,6 +37,8 @@ namespace DbLocalizationProvider.Xliff.Tests
             Assert.NotEmpty(result.Resources);
             Assert.Equal(2, result.Resources.Count);
             Assert.Equal("no", result.Resources.First().Translations.Single().Language);
+			Assert.Equal("det er tekst i norsk", result.Resources.First().Translations.First().Value);
+			Assert.Equal("det er andre tekst i norsk", result.Resources.Skip(1).First().Translations.First().Value);
         }
     }
 }

--- a/Tests/DbLocalizationProvider.Xliff.Tests/packages.config
+++ b/Tests/DbLocalizationProvider.Xliff.Tests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Xliff.OM-Signed" version="1.0.3" targetFramework="net461" />
-  <package id="xunit" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net46" />
 </packages>

--- a/src/DbLocalizationProvider.Xliff/XliffResourceFormatParser.cs
+++ b/src/DbLocalizationProvider.Xliff/XliffResourceFormatParser.cs
@@ -48,7 +48,10 @@ public class FormatParser : IResourceFormatParser
                             Language = targetCulture,
                             Value = resource.Target.Text.OfType<CDataTag>()
                                 .FirstOrDefault()
-                                ?.Text
+                                ?.Text ??
+                                resource.Target.Text.OfType<ResourceStringContent>()
+                                    .FirstOrDefault()?.ToString() ?? 
+                                string.Empty
                         }
                     });
 


### PR DESCRIPTION
Currently it was only possible to import `CData` string in the target language of an XLIFF document.
But the XLIFF standard supports both a `ResourceStringContent` and a `CDataTag` So we now added support for it.

This PR fixes also:

- The `Value` of a `LocalizationResourceTranslation` will now always contains a string and never null
- Add the XLIFF test project to the solution and update it
- Write a test that covers the new behavior 
- Change building to linux, to be able to write better integration tests