### PR TITLE
Add method to transform a class to a translated dictionary

### DIFF
--- a/src/DbLocalizationProvider/ILocalizationProvider.cs
+++ b/src/DbLocalizationProvider/ILocalizationProvider.cs
@@ -140,4 +140,12 @@ public interface ILocalizationProvider
     /// <param name="formatArguments">If you need to format the message and substitute placeholders.</param>
     /// <returns>Translation for current language or in invariant language.</returns>
     string GetStringWithInvariantFallback(Expression<Func<object>> resource, params object[] formatArguments);
+
+    /// <summary>
+    /// Converts a localized resource dictionary to a translated dictionary based on the specified type.
+    /// </summary>
+    /// <param name="type">The type to retrieve localized resources for.</param>
+    /// <returns>A dictionary containing the localized resources translated to the current culture.</returns>
+    /// <exception cref="ArgumentException">Thrown when the object does not have a LocalizedResourceAttribute.</exception>
+    IDictionary<string, string> LocalizedResourceToTranslatedDictionary(Type type);
 }


### PR DESCRIPTION
The use case for this is when you have a smaller classes of translations that you want to output into a dictionary which can easily be transformed into JSON objects. 

Code compiles but have not yet been 100% tested in a website project