### PR TITLE
Ensure dictionaries resolve translation with correct key

### DIFF
--- a/common/src/DbLocalizationProvider/LocalizationProvider.cs
+++ b/common/src/DbLocalizationProvider/LocalizationProvider.cs
@@ -409,7 +409,7 @@ public class LocalizationProvider : ILocalizationProvider
 
             var resourceKey = _keyBuilder.BuildResourceKey(type, property.Name);
 
-            yield return new(resourceKey, GetString(property.Name, culture));
+            yield return new(property.Name, GetString(resourceKey, culture));
         }
     }
 


### PR DESCRIPTION
Noticed an issue with resolving to a dictionary. 
It used the property name instead of the key. 

This PR should resolve the issue. 
I've checked that it works in a existing Optimizely CMS project