### PR TITLE
Target both .NET 8 and .NET 9

### DIFF
--- a/aspnetcore/src/DbLocalizationProvider.AdminUI.AspNetCore.Csv/DbLocalizationProvider.AdminUI.AspNetCore.Csv.csproj
+++ b/aspnetcore/src/DbLocalizationProvider.AdminUI.AspNetCore.Csv/DbLocalizationProvider.AdminUI.AspNetCore.Csv.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Version>9.0.0</Version>
     <Nullable>enable</Nullable>
     <PackageVersion>9.0.0</PackageVersion>

--- a/aspnetcore/src/DbLocalizationProvider.AdminUI.AspNetCore.Xliff/DbLocalizationProvider.AdminUI.AspNetCore.Xliff.csproj
+++ b/aspnetcore/src/DbLocalizationProvider.AdminUI.AspNetCore.Xliff/DbLocalizationProvider.AdminUI.AspNetCore.Xliff.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Version>9.0.0</Version>
     <Nullable>enable</Nullable>
     <PackageVersion>9.0.0</PackageVersion>

--- a/aspnetcore/src/DbLocalizationProvider.AdminUI.AspNetCore/DbLocalizationProvider.AdminUI.AspNetCore.csproj
+++ b/aspnetcore/src/DbLocalizationProvider.AdminUI.AspNetCore/DbLocalizationProvider.AdminUI.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Version>9.0.0</Version>
     <PackageVersion>9.0.0</PackageVersion>

--- a/aspnetcore/src/DbLocalizationProvider.AspNetCore/DbLocalizationProvider.AspNetCore.csproj
+++ b/aspnetcore/src/DbLocalizationProvider.AspNetCore/DbLocalizationProvider.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Version>9.0.0</Version>
     <Nullable>enable</Nullable>
     <PackageVersion>9.0.0</PackageVersion>

--- a/common/Tests/DbLocalizationProvider.Storage.PostgreSql.Tests/DbLocalizationProvider.Storage.PostgreSql.Tests.csproj
+++ b/common/Tests/DbLocalizationProvider.Storage.PostgreSql.Tests/DbLocalizationProvider.Storage.PostgreSql.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\strongname.snk</AssemblyOriginatorKeyFile>

--- a/common/Tests/DbLocalizationProvider.Storage.SqlServer.Tests/DbLocalizationProvider.Storage.SqlServer.Tests.csproj
+++ b/common/Tests/DbLocalizationProvider.Storage.SqlServer.Tests/DbLocalizationProvider.Storage.SqlServer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\strongname.snk</AssemblyOriginatorKeyFile>

--- a/common/Tests/DbLocalizationProvider.Tests/DbLocalizationProvider.Tests.csproj
+++ b/common/Tests/DbLocalizationProvider.Tests/DbLocalizationProvider.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\strongname.snk</AssemblyOriginatorKeyFile>

--- a/common/Tests/DbLocalizationProvider.Xliff.Tests/DbLocalizationProvider.Xliff.Tests.csproj
+++ b/common/Tests/DbLocalizationProvider.Xliff.Tests/DbLocalizationProvider.Xliff.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\strongname.snk</AssemblyOriginatorKeyFile>

--- a/common/src/DbLocalizationProvider.Abstractions/DbLocalizationProvider.Abstractions.csproj
+++ b/common/src/DbLocalizationProvider.Abstractions/DbLocalizationProvider.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/common/src/DbLocalizationProvider.AdminUI.Models/DbLocalizationProvider.AdminUI.Models.csproj
+++ b/common/src/DbLocalizationProvider.AdminUI.Models/DbLocalizationProvider.AdminUI.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/common/src/DbLocalizationProvider.Csv/DbLocalizationProvider.Csv.csproj
+++ b/common/src/DbLocalizationProvider.Csv/DbLocalizationProvider.Csv.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/common/src/DbLocalizationProvider.Storage.AzureTables/DbLocalizationProvider.Storage.AzureTables.csproj
+++ b/common/src/DbLocalizationProvider.Storage.AzureTables/DbLocalizationProvider.Storage.AzureTables.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/common/src/DbLocalizationProvider.Storage.PostgreSQL/DbLocalizationProvider.Storage.PostgreSql.csproj
+++ b/common/src/DbLocalizationProvider.Storage.PostgreSQL/DbLocalizationProvider.Storage.PostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/common/src/DbLocalizationProvider.Storage.SqlServer/DbLocalizationProvider.Storage.SqlServer.csproj
+++ b/common/src/DbLocalizationProvider.Storage.SqlServer/DbLocalizationProvider.Storage.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/common/src/DbLocalizationProvider.Translator.Azure/DbLocalizationProvider.Translator.Azure.csproj
+++ b/common/src/DbLocalizationProvider.Translator.Azure/DbLocalizationProvider.Translator.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/common/src/DbLocalizationProvider.Xliff/DbLocalizationProvider.Xliff.csproj
+++ b/common/src/DbLocalizationProvider.Xliff/DbLocalizationProvider.Xliff.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/common/src/DbLocalizationProvider/DbLocalizationProvider.csproj
+++ b/common/src/DbLocalizationProvider/DbLocalizationProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/optimizely/samples/AlloySampleSite/AlloySampleSite.csproj
+++ b/optimizely/samples/AlloySampleSite/AlloySampleSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EPiServer.CMS.AspNetCore.TagHelpers" Version="12.22.1" />

--- a/optimizely/src/DbLocalizationProvider.AdminUI.EPiServer/DbLocalizationProvider.AdminUI.EPiServer.csproj
+++ b/optimizely/src/DbLocalizationProvider.AdminUI.EPiServer/DbLocalizationProvider.AdminUI.EPiServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Version>9.0.0</Version>
     <PackageVersion>9.0.0</PackageVersion>

--- a/optimizely/src/DbLocalizationProvider.EPiServer/DbLocalizationProvider.EPiServer.csproj
+++ b/optimizely/src/DbLocalizationProvider.EPiServer/DbLocalizationProvider.EPiServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Version>9.0.0</Version>
     <PackageVersion>9.0.0</PackageVersion>

--- a/optimizely/tests/DbLocalizationProvider.EPiServer.Tests/DbLocalizationProvider.EPiServer.Tests.csproj
+++ b/optimizely/tests/DbLocalizationProvider.EPiServer.Tests/DbLocalizationProvider.EPiServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\strongname.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Since .NET 9 will outlive .NET 8, I suppose a number of sites will stay on .NET 8 for some time.

This PR enables compilation for both .NET 8 and .NET 9. Unless you are strict on semantic versioning, where release 9 should only target .NET 9, then there should be no downsides to this change.