### PR TITLE
feat: add methods for deleting and removing registered decorators for commands and queries for greater flexibility when managing external dependencies

### DIFF
--- a/common/src/DbLocalizationProvider/SetHandlerExpression.cs
+++ b/common/src/DbLocalizationProvider/SetHandlerExpression.cs
@@ -67,4 +67,21 @@ public class SetHandlerExpression<T>
     {
         _decoratorMappings.GetOrAdd(typeof(T), typeof(TDecorator));
     }
+    
+    /// <summary>
+    /// Adds or replaces the decorator with the specified type for command or query.
+    /// </summary>
+    /// <typeparam name="TDecorator">The type of the decorator.</typeparam>
+    public void AddOrReplaceDecorator<TDecorator>()
+    {
+        _decoratorMappings.AddOrUpdate(typeof(T), typeof(TDecorator), (_, _) => typeof(TDecorator));
+    }
+    
+    /// <summary>
+    /// Removes the decorator for the specified command or query.
+    /// </summary>
+    public void RemoveDecorator()
+    {
+        _decoratorMappings.TryRemove(typeof(T), out _);
+    }
 }


### PR DESCRIPTION
**There are some complications coming from the immutable way decorators are currently registered**

The problem was originally spotted in the Optimizely packages, specifically method `AddDbLocalizationProvider`, class `IServiceCollectionExtensions`, namespace `DbLocalizationProvider.AspNetCore`. The registration for decorator happens before the custom configurations were injected, and since there is not a method to remove decorator, now we must use `CachedGetAllResourcesHandler`, which is underneath using `_inner` cache, from which I would like to migrate to a custom solution.

Line 47: `factory.ForQuery<GetAllResources.Query>().DecorateWith<CachedGetAllResourcesHandler>();`
Line 60: `setup?.Invoke(ctx);`

Obviously, we could solve it in the same file by "swapping" the lines and registering some decorator, which would block registration of `CachedGetAllResourcesHandler` - but I believe it is much more useful to address the root cause here and create an alternative in case similar problems will be spotted in other places. I added two methods: `AddOrReplaceDecorator` and `RemoveDecorator` - which could be handy. They allow to replace existing decorators or clear them completely, if using them is no longer expected.

**PR enables replacing externally registered decorators, therefore making the application more extensible and comfortable for developers in the long run.**